### PR TITLE
fix(release-please): set initial version to 0.1.0

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -8,7 +8,8 @@
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
       "prerelease": false,
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "initial-version": "0.1.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rag-facile",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "description": "An AI-powered PDF assistant that lets you chat with any PDF document. Index PDFs from URLs, ask questions about content, and generate quizzes from the material.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Added `initial-version: "0.1.0"` to release-please config
- This ensures the first release will be `0.1.0` instead of `1.0.0`

The `bump-minor-pre-major` setting only affects version bumping behavior **after** reaching 0.x.x — it doesn't change the default initial release version of `1.0.0`. By explicitly setting `initial-version`, we ensure the project starts at `0.1.0`.

## Context

Closed PR #3 which was creating `1.0.0` as the first release. With this fix, release-please will create `0.1.0` instead.

## Test plan

After merging, the next release-please run should create a PR for `0.1.0` instead of `1.0.0`.

👾 Generated with [Letta Code](https://letta.com)