### PR TITLE
feat: add Biome linting, Husky pre-commit hooks, and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+      - name: Setup proto toolchain
+        uses: moonrepo/setup-toolchain@v0
         with:
-          version: 10
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          cache: "pnpm"
+          auto-install: true
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run Biome (lint + format check)
+        run: pnpm lint
+
+      - name: Run TypeScript type check
+        run: pnpm typecheck

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,8 @@
+# Biome: format, lint, and organize imports
+pnpm biome check --write --no-errors-on-unmatched
+
+# TypeScript: type check
+pnpm tsc --noEmit
+
+# GitLeaks: secret detection (staged files only)
+gitleaks git --staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,8 +1,5 @@
-# Biome: format, lint, and organize imports
-pnpm biome check --write --no-errors-on-unmatched
-
-# TypeScript: type check
-pnpm tsc --noEmit
+# lint-staged: runs formatters + typecheck on staged files only
+pnpm lint-staged
 
 # GitLeaks: secret detection (staged files only)
 gitleaks git --staged

--- a/.prototools
+++ b/.prototools
@@ -1,0 +1,5 @@
+pnpm = "10.29.3"
+node = "~22"
+
+[settings]
+auto-install = true

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["src/**/*.ts", "src/**/*.js"]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "es5"
+    }
+  },
+  "assist": {
+    "enabled": true,
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,11 @@
     "@types/node": "^25.2.3",
     "@types/pdf-parse": "^1.1.5",
     "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "mastra": "latest",
     "typescript": "^5.9.3"
+  },
+  "lint-staged": {
+    "*.{ts,js}": ["biome check --write", "tsc --noEmit --skipLibCheck"]
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,12 @@
   "scripts": {
     "dev": "mastra dev",
     "build": "mastra build",
-    "start": "mastra start"
+    "start": "mastra start",
+    "prepare": "husky",
+    "lint": "biome check",
+    "lint:fix": "biome check --write",
+    "format": "biome format --write",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [],
   "author": "",
@@ -29,9 +34,11 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@biomejs/biome": "^2.4.11",
     "@mastra/mcp": "^1.4.2",
     "@types/node": "^25.2.3",
     "@types/pdf-parse": "^1.1.5",
+    "husky": "^9.1.7",
     "mastra": "latest",
     "typescript": "^5.9.3"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       mastra:
         specifier: latest
         version: 1.5.0(@hono/node-server@1.19.13(hono@4.12.12))(@mastra/core@1.24.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))(typescript@5.9.3)(zod@4.3.6)
@@ -1171,6 +1174,10 @@ packages:
   ansi-align@3.0.1:
     resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1371,6 +1378,14 @@ packages:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
   clipboardy@3.0.0:
     resolution: {integrity: sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -1561,6 +1576,9 @@ packages:
   electron-to-chromium@1.5.334:
     resolution: {integrity: sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1577,6 +1595,10 @@ packages:
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
 
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
@@ -1628,6 +1650,9 @@ packages:
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -1789,6 +1814,10 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -1953,6 +1982,10 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -2074,6 +2107,15 @@ packages:
     cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
   local-pkg@1.1.2:
     resolution: {integrity: sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==}
     engines: {node: '>=14'}
@@ -2083,6 +2125,10 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -2295,6 +2341,10 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
@@ -2406,6 +2456,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   openapi-fetch@0.17.0:
     resolution: {integrity: sha512-PsbZR1wAPcG91eEthKhN+Zn92FMHxv+/faECIwjXdxfTODGSGegYv0sc1Olz+HYPvKOuoXfp+0pA2XVt2cI0Ig==}
@@ -2639,9 +2693,16 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
   rollup-plugin-esbuild@6.2.1:
     resolution: {integrity: sha512-jTNOMGoMRhs0JuueJrJqbW8tOwxumaWYq+V5i+PD+8ecSCVkuX27tGW7BXqDgoULQ55rO7IdNxPcnsWtshz3AA==}
@@ -2767,6 +2828,14 @@ packages:
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
@@ -2787,6 +2856,10 @@ packages:
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
   string-similarity@4.0.4:
     resolution: {integrity: sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -2798,6 +2871,14 @@ packages:
   string-width@5.1.2:
     resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
     engines: {node: '>=12'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
 
   string_decoder@1.1.1:
     resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
@@ -2856,6 +2937,10 @@ packages:
   thread-stream@4.0.0:
     resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
     engines: {node: '>=20'}
+
+  tinyexec@1.1.1:
+    resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -3007,6 +3092,10 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -4150,6 +4239,10 @@ snapshots:
     dependencies:
       string-width: 4.2.3
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -4367,6 +4460,15 @@ snapshots:
 
   cli-boxes@3.0.0: {}
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
+
   clipboardy@3.0.0:
     dependencies:
       arch: 2.2.0
@@ -4523,6 +4625,8 @@ snapshots:
 
   electron-to-chromium@1.5.334: {}
 
+  emoji-regex@10.6.0: {}
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -4534,6 +4638,8 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+
+  environment@1.1.0: {}
 
   es-define-property@1.0.1: {}
 
@@ -4594,6 +4700,8 @@ snapshots:
   etag@1.8.1: {}
 
   event-target-shim@5.0.1: {}
+
+  eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -4841,6 +4949,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-east-asian-width@1.5.0: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -4977,6 +5087,10 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -5079,6 +5193,24 @@ snapshots:
       '@libsql/linux-x64-musl': 0.5.29
       '@libsql/win32-x64-msvc': 0.5.29
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
   local-pkg@1.1.2:
     dependencies:
       mlly: 1.8.2
@@ -5088,6 +5220,14 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash@4.18.1: {}
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
 
   longest-streak@3.1.0: {}
 
@@ -5476,6 +5616,8 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
+  mimic-function@5.0.1: {}
+
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.13
@@ -5567,6 +5709,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   openapi-fetch@0.17.0:
     dependencies:
@@ -5826,7 +5972,14 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.27.7)(rollup@4.60.1):
     dependencies:
@@ -6031,6 +6184,16 @@ snapshots:
 
   sisteransi@1.0.5: {}
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   sonic-boom@4.2.1:
     dependencies:
       atomic-sleep: 1.0.0
@@ -6056,6 +6219,8 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  string-argv@0.3.2: {}
+
   string-similarity@4.0.4: {}
 
   string-width@4.2.3:
@@ -6068,6 +6233,17 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
   string_decoder@1.1.1:
@@ -6131,6 +6307,8 @@ snapshots:
   thread-stream@4.0.0:
     dependencies:
       real-require: 0.2.0
+
+  tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
     dependencies:
@@ -6276,6 +6454,12 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@biomejs/biome':
+        specifier: ^2.4.11
+        version: 2.4.11
       '@mastra/mcp':
         specifier: ^1.4.2
         version: 1.4.2(@mastra/core@1.24.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(zod@4.3.6)
@@ -48,6 +51,9 @@ importers:
       '@types/pdf-parse':
         specifier: ^1.1.5
         version: 1.1.5
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       mastra:
         specifier: latest
         version: 1.5.0(@hono/node-server@1.19.13(hono@4.12.12))(@mastra/core@1.24.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.3.6))(zod@4.3.6))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.3.6))(@types/json-schema@7.0.15)(openapi-types@12.1.3)(zod@4.3.6))(typescript@5.9.3)(zod@4.3.6)
@@ -235,6 +241,63 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@biomejs/biome@2.4.11':
+    resolution: {integrity: sha512-nWxHX8tf3Opb/qRgZpBbsTOqOodkbrkJ7S+JxJAruxOReaDPPmPuLBAGQ8vigyUgo0QBB+oQltNEAvalLcjggA==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
+  '@biomejs/cli-darwin-arm64@2.4.11':
+    resolution: {integrity: sha512-wOt+ed+L2dgZanWyL6i29qlXMc088N11optzpo10peayObBaAshbTcxKUchzEMp9QSY8rh5h6VfAFE3WTS1rqg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-x64@2.4.11':
+    resolution: {integrity: sha512-gZ6zR8XmZlExfi/Pz/PffmdpWOQ8Qhy7oBztgkR8/ylSRyLwfRPSadmiVCV8WQ8PoJ2MWUy2fgID9zmtgUUJmw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.11':
+    resolution: {integrity: sha512-+Sbo1OAmlegtdwqFE8iOxFIWLh1B3OEgsuZfBpyyN/kWuqZ8dx9ZEes6zVnDMo+zRHF2wLynRVhoQmV7ohxl2Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-arm64@2.4.11':
+    resolution: {integrity: sha512-avdJaEElXrKceK0va9FkJ4P5ci3N01TGkc6ni3P8l3BElqbOz42Wg2IyX3gbh0ZLEd4HVKEIrmuVu/AMuSeFFA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-linux-x64-musl@2.4.11':
+    resolution: {integrity: sha512-bexd2IklK7ZgPhrz6jXzpIL6dEAH9MlJU1xGTrypx+FICxrXUp4CqtwfiuoDKse+UlgAlWtzML3jrMqeEAHEhA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@biomejs/cli-linux-x64@2.4.11':
+    resolution: {integrity: sha512-TagWV0iomp5LnEnxWFg4nQO+e52Fow349vaX0Q/PIcX6Zhk4GGBgp3qqZ8PVkpC+cuehRctMf3+6+FgQ8jCEFQ==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@biomejs/cli-win32-arm64@2.4.11':
+    resolution: {integrity: sha512-RJhaTnY8byzxDt4bDVb7AFPHkPcjOPK3xBip4ZRTrN3TEfyhjLRm3r3mqknqydgVTB74XG8l4jMLwEACEeihVg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.11':
+    resolution: {integrity: sha512-A8D3JM/00C2KQgUV3oj8Ba15EHEYwebAGCy5Sf9GAjr5Y3+kJIYOiESoqRDeuRZueuMdCsbLZIUqmPhpYXJE9A==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
 
   '@clack/core@1.2.0':
     resolution: {integrity: sha512-qfxof/3T3t9DPU/Rj3OmcFyZInceqj/NVtO9rwIuJqCUgh32gwPjpFQQp/ben07qKlhpwq7GzfWpST4qdJ5Drg==}
@@ -1830,6 +1893,11 @@ packages:
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -3248,6 +3316,41 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@biomejs/biome@2.4.11':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.11
+      '@biomejs/cli-darwin-x64': 2.4.11
+      '@biomejs/cli-linux-arm64': 2.4.11
+      '@biomejs/cli-linux-arm64-musl': 2.4.11
+      '@biomejs/cli-linux-x64': 2.4.11
+      '@biomejs/cli-linux-x64-musl': 2.4.11
+      '@biomejs/cli-win32-arm64': 2.4.11
+      '@biomejs/cli-win32-x64': 2.4.11
+
+  '@biomejs/cli-darwin-arm64@2.4.11':
+    optional: true
+
+  '@biomejs/cli-darwin-x64@2.4.11':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.11':
+    optional: true
+
+  '@biomejs/cli-linux-arm64@2.4.11':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.11':
+    optional: true
+
+  '@biomejs/cli-linux-x64@2.4.11':
+    optional: true
+
+  '@biomejs/cli-win32-arm64@2.4.11':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.11':
+    optional: true
 
   '@clack/core@1.2.0':
     dependencies:
@@ -4837,6 +4940,8 @@ snapshots:
   humanize-ms@1.2.1:
     dependencies:
       ms: 2.1.3
+
+  husky@9.1.7: {}
 
   iconv-lite@0.4.24:
     dependencies:

--- a/src/mastra/agents/pdf-chat-agent.ts
+++ b/src/mastra/agents/pdf-chat-agent.ts
@@ -1,12 +1,12 @@
-import { Agent } from '@mastra/core/agent';
-import { Memory } from '@mastra/memory';
-import { pdfQueryTool } from '../tools/pdf-query-tool';
-import { listDocumentsTool } from '../tools/list-documents-tool';
-import { indexPdfWorkflow } from '../workflows/index-pdf';
+import { Agent } from "@mastra/core/agent";
+import { Memory } from "@mastra/memory";
+import { listDocumentsTool } from "../tools/list-documents-tool";
+import { pdfQueryTool } from "../tools/pdf-query-tool";
+import { indexPdfWorkflow } from "../workflows/index-pdf";
 
 export const pdfChatAgent = new Agent({
-  id: 'pdf-chat-agent',
-  name: 'Chat with PDF',
+  id: "pdf-chat-agent",
+  name: "Chat with PDF",
   instructions: `You are an AI assistant that helps users understand and interact with PDF documents. You can answer questions about document content, summarize sections, and generate quizzes to test comprehension.
 
 ## Your Capabilities
@@ -156,7 +156,7 @@ When asking about code examples:
 - Be encouraging and supportive when running quizzes - learning is the goal!
 `,
   model: {
-    id: 'albert-api/openai/gpt-oss-120b',
+    id: "albert-api/openai/gpt-oss-120b",
     url: process.env.OPENAI_BASE_URL,
     apiKey: process.env.OPENAI_API_KEY,
   },

--- a/src/mastra/index.ts
+++ b/src/mastra/index.ts
@@ -1,20 +1,20 @@
-import { Mastra } from '@mastra/core/mastra';
-import { PinoLogger } from '@mastra/loggers';
-import { LibSQLStore } from '@mastra/libsql';
-import { indexPdfWorkflow } from './workflows/index-pdf';
-import { pdfChatAgent } from './agents/pdf-chat-agent';
-import { vectorStore } from './lib/vector-store';
+import { Mastra } from "@mastra/core/mastra";
+import { LibSQLStore } from "@mastra/libsql";
+import { PinoLogger } from "@mastra/loggers";
+import { pdfChatAgent } from "./agents/pdf-chat-agent";
+import { vectorStore } from "./lib/vector-store";
+import { indexPdfWorkflow } from "./workflows/index-pdf";
 
 export const mastra = new Mastra({
   workflows: { indexPdfWorkflow },
   agents: { pdfChatAgent },
   vectors: { vectorStore },
   storage: new LibSQLStore({
-    id: 'mastra-storage',
-    url: 'file:./mastra.db',
+    id: "mastra-storage",
+    url: "file:./mastra.db",
   }),
   logger: new PinoLogger({
-    name: 'Mastra',
-    level: 'info',
+    name: "Mastra",
+    level: "info",
   }),
 });

--- a/src/mastra/lib/vector-store.ts
+++ b/src/mastra/lib/vector-store.ts
@@ -1,8 +1,8 @@
-import { LibSQLVector } from '@mastra/libsql';
+import { LibSQLVector } from "@mastra/libsql";
 
 export const vectorStore = new LibSQLVector({
-  id: 'pdf-vectors',
-  url: 'file:./mastra.db',
+  id: "pdf-vectors",
+  url: "file:./mastra.db",
 });
 
-export const PDF_INDEX_NAME = 'pdf_sections';
+export const PDF_INDEX_NAME = "pdf_sections";

--- a/src/mastra/tools/list-documents-tool.ts
+++ b/src/mastra/tools/list-documents-tool.ts
@@ -1,10 +1,10 @@
-import { createTool } from '@mastra/core/tools';
-import { z } from 'zod';
-import { ModelRouterEmbeddingModel } from '@mastra/core/llm';
-import { vectorStore, PDF_INDEX_NAME } from '../lib/vector-store';
+import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import { PDF_INDEX_NAME, vectorStore } from "../lib/vector-store";
 
 export const listDocumentsTool = createTool({
-  id: 'list-documents',
+  id: "list-documents",
   description: `List all indexed PDF documents available for quizzing.
 Use this tool when:
 - The user asks what documents/books are available
@@ -23,8 +23,8 @@ Use this tool when:
       // A cleaner approach would be a separate document registry, but this keeps the
       // template simple with fewer moving parts. For production, consider tracking
       // indexed documents in your own database.
-      const embeddingModel = new ModelRouterEmbeddingModel('openai/text-embedding-3-small');
-      const { embeddings } = await embeddingModel.doEmbed({ values: ['document'] });
+      const embeddingModel = new ModelRouterEmbeddingModel("openai/text-embedding-3-small");
+      const { embeddings } = await embeddingModel.doEmbed({ values: ["document"] });
 
       const results = await vectorStore.query({
         indexName: PDF_INDEX_NAME,
@@ -47,7 +47,7 @@ Use this tool when:
         if (docId && !documentsMap.has(docId)) {
           documentsMap.set(docId, {
             documentId: docId,
-            title: (result.metadata?.documentTitle as string) || 'Untitled',
+            title: (result.metadata?.documentTitle as string) || "Untitled",
             totalPages: (result.metadata?.totalPages as number) || 0,
           });
         }
@@ -58,7 +58,7 @@ Use this tool when:
       if (documents.length === 0) {
         return {
           documents: [],
-          message: 'No documents have been indexed yet. Use the index-pdf workflow to add a PDF.',
+          message: "No documents have been indexed yet. Use the index-pdf workflow to add a PDF.",
         };
       }
 
@@ -69,7 +69,7 @@ Use this tool when:
     } catch {
       return {
         documents: [],
-        message: 'Could not retrieve documents. The vector index may not exist yet.',
+        message: "Could not retrieve documents. The vector index may not exist yet.",
       };
     }
   },

--- a/src/mastra/tools/pdf-query-tool.ts
+++ b/src/mastra/tools/pdf-query-tool.ts
@@ -92,7 +92,7 @@ For general topic searches without page constraints, omit pageStart/pageEnd.`,
 
     for (const page of selectedPages) {
       try {
-        const filter = { pageNumber: page } as { pageNumber: number; documentId?: string };
+        const filter: { pageNumber: number; documentId?: string } = { pageNumber: page };
         if (documentId) {
           filter.documentId = documentId;
         }

--- a/src/mastra/tools/pdf-query-tool.ts
+++ b/src/mastra/tools/pdf-query-tool.ts
@@ -1,10 +1,10 @@
-import { createTool } from '@mastra/core/tools';
-import { z } from 'zod';
-import { ModelRouterEmbeddingModel } from '@mastra/core/llm';
-import { vectorStore, PDF_INDEX_NAME } from '../lib/vector-store';
+import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+import { PDF_INDEX_NAME, vectorStore } from "../lib/vector-store";
 
 export const pdfQueryTool = createTool({
-  id: 'query-pdf-content',
+  id: "query-pdf-content",
   description: `Search PDF content with even distribution across page ranges.
 
 When the user specifies pages (e.g., "pages 50-67"), use pageStart and pageEnd.
@@ -12,14 +12,17 @@ The tool retrieves chunks from EACH page in the range, ensuring full coverage.
 
 For general topic searches without page constraints, omit pageStart/pageEnd.`,
   inputSchema: z.object({
-    queryText: z.string().describe('Semantic search query describing the content to find'),
-    documentId: z.string().optional().describe('Filter by specific document ID (from list-documents tool)'),
-    pageStart: z.number().optional().describe('Start of page range (inclusive)'),
-    pageEnd: z.number().optional().describe('End of page range (inclusive)'),
+    queryText: z.string().describe("Semantic search query describing the content to find"),
+    documentId: z
+      .string()
+      .optional()
+      .describe("Filter by specific document ID (from list-documents tool)"),
+    pageStart: z.number().optional().describe("Start of page range (inclusive)"),
+    pageEnd: z.number().optional().describe("End of page range (inclusive)"),
   }),
   execute: async ({ queryText, documentId, pageStart, pageEnd }) => {
     // Generate embedding for the query using Mastra's model router
-    const embeddingModel = new ModelRouterEmbeddingModel('openai/text-embedding-3-small');
+    const embeddingModel = new ModelRouterEmbeddingModel("openai/text-embedding-3-small");
     const { embeddings } = await embeddingModel.doEmbed({ values: [queryText] });
     const queryVector = embeddings[0];
 
@@ -33,8 +36,8 @@ For general topic searches without page constraints, omit pageStart/pageEnd.`,
       });
 
       return {
-        chunks: results.map(r => ({
-          text: r.metadata?.text || '',
+        chunks: results.map((r) => ({
+          text: r.metadata?.text || "",
           pageNumber: r.metadata?.pageNumber,
           documentTitle: r.metadata?.documentTitle,
           score: r.score,
@@ -89,7 +92,7 @@ For general topic searches without page constraints, omit pageStart/pageEnd.`,
 
     for (const page of selectedPages) {
       try {
-        const filter: Record<string, any> = { pageNumber: page };
+        const filter = { pageNumber: page } as { pageNumber: number; documentId?: string };
         if (documentId) {
           filter.documentId = documentId;
         }
@@ -103,12 +106,12 @@ For general topic searches without page constraints, omit pageStart/pageEnd.`,
 
         for (const r of pageResults) {
           results.push({
-            text: (r.metadata?.text as string) || '',
+            text: (r.metadata?.text as string) || "",
             pageNumber: page,
             score: r.score || 0,
           });
         }
-      } catch (error) {
+      } catch (_error) {
         // Page may have no chunks
       }
     }
@@ -121,7 +124,7 @@ For general topic searches without page constraints, omit pageStart/pageEnd.`,
       pagesCovered: `${pageStart}-${pageEnd}`,
       pagesReturned: selectedPages.sort((a, b) => a - b),
       totalChunks: shuffledResults.length,
-      note: 'Stratified sample: chunks from early, middle, AND late pages. Each chunk has a pageNumber - use it for the hint.',
+      note: "Stratified sample: chunks from early, middle, AND late pages. Each chunk has a pageNumber - use it for the hint.",
     };
   },
 });

--- a/src/mastra/workflows/index-pdf.ts
+++ b/src/mastra/workflows/index-pdf.ts
@@ -1,9 +1,9 @@
-import { createStep, createWorkflow } from '@mastra/core/workflows';
-import { ModelRouterEmbeddingModel } from '@mastra/core/llm';
-import { MDocument } from '@mastra/rag';
-import { z } from 'zod';
-import { PDFParse } from 'pdf-parse';
-import { vectorStore, PDF_INDEX_NAME } from '../lib/vector-store';
+import { ModelRouterEmbeddingModel } from "@mastra/core/llm";
+import { createStep, createWorkflow } from "@mastra/core/workflows";
+import { MDocument } from "@mastra/rag";
+import { PDFParse } from "pdf-parse";
+import { z } from "zod";
+import { PDF_INDEX_NAME, vectorStore } from "../lib/vector-store";
 
 const EMBEDDING_DIMENSION = 1536; // OpenAI text-embedding-3-small
 
@@ -11,15 +11,15 @@ const EMBEDDING_DIMENSION = 1536; // OpenAI text-embedding-3-small
  * SSRF protection: Validate URL before fetching
  * Blocks internal/private network addresses to prevent server-side request forgery
  */
-const ALLOWED_PROTOCOLS = ['http:', 'https:'];
+const ALLOWED_PROTOCOLS = ["http:", "https:"];
 const BLOCKED_HOSTS = [
-  'localhost',
-  '127.0.0.1',
-  '0.0.0.0',
-  '::1',
-  '169.254.169.254', // AWS/GCP metadata
-  'metadata.google.internal',
-  'metadata.azure.net',
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "::1",
+  "169.254.169.254", // AWS/GCP metadata
+  "metadata.google.internal",
+  "metadata.azure.net",
 ];
 
 function validateUrl(url: string): void {
@@ -42,7 +42,8 @@ function validateUrl(url: string): void {
   }
 
   // Block private IP ranges (10.x, 172.16-31.x, 192.168.x)
-  const privateIpPattern = /^(10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+)$/;
+  const privateIpPattern =
+    /^(10\.\d+\.\d+\.\d+|172\.(1[6-9]|2\d|3[01])\.\d+\.\d+|192\.168\.\d+\.\d+)$/;
   if (privateIpPattern.test(hostname)) {
     throw new Error(`Access to private IP range is blocked: ${hostname}`);
   }
@@ -54,7 +55,7 @@ async function initializeVectorIndex(): Promise<void> {
     await vectorStore.createIndex({
       indexName: PDF_INDEX_NAME,
       dimension: EMBEDDING_DIMENSION,
-      metric: 'cosine',
+      metric: "cosine",
     });
   }
 }
@@ -63,10 +64,10 @@ async function initializeVectorIndex(): Promise<void> {
  * Step 1: Download PDF and extract text from each page
  */
 const downloadAndExtractText = createStep({
-  id: 'download-and-extract-text',
-  description: 'Download PDF from URL and extract text page by page',
+  id: "download-and-extract-text",
+  description: "Download PDF from URL and extract text page by page",
   inputSchema: z.object({
-    url: z.url().describe('URL of the PDF to ingest'),
+    url: z.url().describe("URL of the PDF to ingest"),
   }),
   outputSchema: z.object({
     documentId: z.string(),
@@ -77,12 +78,12 @@ const downloadAndExtractText = createStep({
       z.object({
         pageNumber: z.number(),
         content: z.string(),
-      }),
+      })
     ),
   }),
   execute: async ({ inputData }) => {
     if (!inputData) {
-      throw new Error('Input data not found');
+      throw new Error("Input data not found");
     }
 
     const { url } = inputData;
@@ -136,8 +137,8 @@ const downloadAndExtractText = createStep({
  * Step 2: Split pages into smaller chunks for embedding
  */
 const splitIntoChunks = createStep({
-  id: 'split-into-chunks',
-  description: 'Split page text into smaller overlapping chunks',
+  id: "split-into-chunks",
+  description: "Split page text into smaller overlapping chunks",
   inputSchema: z.object({
     documentId: z.string(),
     title: z.string(),
@@ -154,11 +155,11 @@ const splitIntoChunks = createStep({
       z.object({
         text: z.string(),
         metadata: z.record(z.string(), z.any()),
-      }),
+      })
     ),
   }),
   execute: async ({ inputData: { documentId, title, url, totalPages, pages } }) => {
-    const allChunks: { text: string; metadata: Record<string, any> }[] = [];
+    const allChunks: { text: string; metadata: Record<string, unknown> }[] = [];
 
     for (const page of pages) {
       // Create MDocument from page content
@@ -169,7 +170,7 @@ const splitIntoChunks = createStep({
 
       // Chunk using recursive strategy
       const chunks = await doc.chunk({
-        strategy: 'recursive',
+        strategy: "recursive",
         maxSize: 512,
         overlap: 50,
       });
@@ -203,8 +204,8 @@ const splitIntoChunks = createStep({
  * Step 3: Generate embeddings and store in vector database
  */
 const generateAndStoreEmbeddings = createStep({
-  id: 'generate-and-store-embeddings',
-  description: 'Generate embeddings for each chunk and store in vector database',
+  id: "generate-and-store-embeddings",
+  description: "Generate embeddings for each chunk and store in vector database",
   inputSchema: z.object({
     documentId: z.string(),
     title: z.string(),
@@ -214,7 +215,7 @@ const generateAndStoreEmbeddings = createStep({
       z.object({
         text: z.string(),
         metadata: z.record(z.string(), z.any()),
-      }),
+      })
     ),
   }),
   outputSchema: z.object({
@@ -229,8 +230,8 @@ const generateAndStoreEmbeddings = createStep({
 
     // Generate embeddings using Mastra's model router
     // Batch to stay under OpenAI's 2048 values per call limit
-    const embeddingModel = new ModelRouterEmbeddingModel('openai/text-embedding-3-small');
-    const texts = chunks.map(c => c.text);
+    const embeddingModel = new ModelRouterEmbeddingModel("openai/text-embedding-3-small");
+    const texts = chunks.map((c) => c.text);
     const BATCH_SIZE = 2000;
     const embeddings: number[][] = [];
 
@@ -243,7 +244,7 @@ const generateAndStoreEmbeddings = createStep({
     }
 
     // Prepare metadata for storage
-    const metadata = chunks.map(c => ({
+    const metadata = chunks.map((c) => ({
       text: c.text,
       ...c.metadata,
     }));
@@ -276,9 +277,9 @@ const generateAndStoreEmbeddings = createStep({
 
 // Create the workflow
 const indexPdfWorkflow = createWorkflow({
-  id: 'index-pdf',
+  id: "index-pdf",
   inputSchema: z.object({
-    url: z.url().describe('URL of the PDF to ingest'),
+    url: z.url().describe("URL of the PDF to ingest"),
   }),
   outputSchema: z.object({
     documentId: z.string(),
@@ -299,13 +300,13 @@ export { indexPdfWorkflow };
 function extractTitleFromUrl(url: string): string {
   try {
     const pathname = new URL(url).pathname;
-    const filename = pathname.split('/').pop() || 'document';
-    return filename.replace(/\.pdf$/i, '').replace(/[-_]/g, ' ');
+    const filename = pathname.split("/").pop() || "document";
+    return filename.replace(/\.pdf$/i, "").replace(/[-_]/g, " ");
   } catch {
-    return 'Untitled PDF';
+    return "Untitled PDF";
   }
 }
 
 function generateDocumentId(url: string): string {
-  return `pdf-${Buffer.from(url).toString('base64url').slice(-12)}`;
+  return `pdf-${Buffer.from(url).toString("base64url").slice(-12)}`;
 }

--- a/src/mastra/workflows/index-pdf.ts
+++ b/src/mastra/workflows/index-pdf.ts
@@ -154,7 +154,7 @@ const splitIntoChunks = createStep({
     chunks: z.array(
       z.object({
         text: z.string(),
-        metadata: z.record(z.string(), z.any()),
+        metadata: z.record(z.string(), z.unknown()),
       })
     ),
   }),
@@ -214,7 +214,7 @@ const generateAndStoreEmbeddings = createStep({
     chunks: z.array(
       z.object({
         text: z.string(),
-        metadata: z.record(z.string(), z.any()),
+        metadata: z.record(z.string(), z.unknown()),
       })
     ),
   }),


### PR DESCRIPTION
## Summary
- Add **Biome** for fast linting and formatting (Rust-based tool)
- Add **Husky** pre-commit hooks that run: Biome check, TypeScript type checking, GitLeaks secret detection
- Add **GitHub CI workflow** for lint + typecheck on push/PR to main
- Fix existing lint issues (replace `any` types, prefix unused variables)
- Format all source files with Biome

## New Scripts
- `pnpm lint` - Run Biome check
- `pnpm lint:fix` - Run Biome check with auto-fix
- `pnpm format` - Run Biome format
- `pnpm typecheck` - Run TypeScript type check

## Pre-commit Hooks
Run automatically before each commit:
1. Biome: format, lint, and organize imports
2. TypeScript: type check
3. GitLeaks: secret detection on staged files

## Test plan
- [x] Run `pnpm lint` - passes with no errors
- [x] Run `pnpm typecheck` - passes with no errors
- [x] Pre-commit hooks execute correctly
- [x] GitLeaks detects no secrets in codebase

👾 Generated with [Letta Code](https://letta.com)