### PR TITLE
feat: add Mastra framework skill

### DIFF
--- a/.agents/skills/mastra/SKILL.md
+++ b/.agents/skills/mastra/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: mastra
+description: "Comprehensive Mastra framework guide. Teaches how to find current documentation, verify API signatures, and build agents and workflows. Covers documentation lookup strategies (embedded docs, remote docs), core concepts (agents vs workflows, tools, memory, RAG), TypeScript requirements, and common patterns. Use this skill for all Mastra development to ensure you're using current APIs from the installed version or latest documentation."
+license: Apache-2.0
+metadata:
+  author: Mastra
+  version: "2.0.0"
+  repository: https://github.com/mastra-ai/skills
+---
+
+# Mastra Framework Guide
+
+Build AI applications with Mastra. This skill teaches you how to find current documentation and build agents and workflows.
+
+## ⚠️ Critical: Do not trust internal knowledge
+
+Everything you know about Mastra is likely outdated or wrong. Never rely on memory. Always verify against current documentation.
+
+Your training data contains obsolete APIs, deprecated patterns, and incorrect usage. Mastra evolves rapidly - APIs change between versions, constructor signatures shift, and patterns get refactored.
+
+## Prerequisites
+
+Before writing any Mastra code, check if packages are installed:
+
+```bash
+ls node_modules/@mastra/
+```
+
+- **If packages exist:** Use embedded docs first (most reliable)
+- **If no packages:** Install first or use remote docs
+
+## Available files
+
+### References
+
+| User Question                       | First Check                                                      | How To                                         |
+| ----------------------------------- | ---------------------------------------------------------------- | ---------------------------------------------- |
+| "Create/install Mastra project"     | [`references/create-mastra.md`](references/create-mastra.md)     | Setup guide with CLI and manual steps          |
+| "How do I use Agent/Workflow/Tool?" | [`references/embedded-docs.md`](references/embedded-docs.md)     | Look up in `node_modules/@mastra/*/dist/docs/` |
+| "How do I use X?" (no packages)     | [`references/remote-docs.md`](references/remote-docs.md)         | Fetch from `https://mastra.ai/llms.txt`        |
+| "I'm getting an error..."           | [`references/common-errors.md`](references/common-errors.md)     | Common errors and solutions                    |
+| "Upgrade from v0.x to v1.x"         | [`references/migration-guide.md`](references/migration-guide.md) | Version upgrade workflows                      |
+
+### Scripts
+
+- `scripts/provider-registry.mjs`: Look up current providers and models available in the model router. Always run this before using a model to verify provider keys and model names.
+
+## Priority order for writing code
+
+⚠️ Never write code without checking current docs first.
+
+1. **Embedded docs first** (if packages installed)
+
+   Look up current docs in `node_modules` for a package. Example of looking up "Agent" docs in `@mastra/core`:
+
+   ```bash
+   grep -r "Agent" node_modules/@mastra/core/dist/docs/references
+   ```
+
+   - **Why:** Matches your EXACT installed version
+   - **Most reliable source of truth**
+   - **More information:** [`references/embedded-docs.md`](references/embedded-docs.md)
+
+2. **Source code second** (if packages installed)
+
+   If you can't find what you need in the embedded docs, look directly at the source code. This is more time consuming but can provide insights into implementation details.
+
+   ```bash
+   # Check what's available
+   cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"Agent"'
+
+   # Read the actual type definition
+   cat node_modules/@mastra/core/dist/[path-from-source-map]
+   ```
+
+   - **Why:** Ultimate source of truth if docs are missing or unclear
+   - **Use when:** Embedded docs don't cover your question
+   - **More information:** [`references/embedded-docs.md`](references/embedded-docs.md)
+
+3. **Remote docs third** (if packages not installed)
+
+   You can fetch the latest docs from the Mastra website:
+
+   ```bash
+   https://mastra.ai/llms.txt
+   ```
+
+   - **Why:** Latest published docs (may be ahead of installed version)
+   - **Use when:** Packages not installed or exploring new features
+   - **More information:** [`references/remote-docs.md`](references/remote-docs.md)
+
+## Core concepts
+
+### Agents vs workflows
+
+**Agent**: Autonomous, makes decisions, uses tools
+Use for: Open-ended tasks (support, research, analysis)
+
+**Workflow**: Structured sequence of steps
+Use for: Defined processes (pipelines, approvals, ETL)
+
+### Key components
+
+- **Tools**: Extend agent capabilities (APIs, databases, external services)
+- **Memory**: Maintain context (message history, working memory, semantic recall, observational memory)
+- **RAG**: Query external knowledge (vector stores, graph relationships)
+- **Storage**: Persist data (Postgres, LibSQL, MongoDB)
+
+### Mastra Studio
+
+Studio provides an interactive UI for building, testing, and managing agents, workflows, and tools. It helps with debugging and improving your applications iteratively.
+
+Inside a Mastra project, run:
+
+```bash
+npm run dev
+```
+
+Then open `http://localhost:4111` in your browser to access Mastra Studio.
+
+## Critical requirements
+
+### TypeScript config
+
+Mastra requires **ES2022 modules**. CommonJS will fail.
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler"
+  }
+}
+```
+
+### Model format
+
+Always use `"provider/model-name"` when defining models using Mastra's model router.
+
+Use the provider registry script to look up available providers and models:
+
+```bash
+# List all available providers
+node scripts/provider-registry.mjs --list
+
+# List all models for a specific provider (sorted newest first)
+node scripts/provider-registry.mjs --provider openai
+node scripts/provider-registry.mjs --provider anthropic
+```
+
+When the user asks to use a model or provider, **always run the script first** to verify the provider key and model name are valid. Do not guess model names from memory as they change frequently.
+
+Example model strings:
+
+- `"openai/gpt-5.4"`
+- `"anthropic/claude-sonnet-4-5"`
+- `"google/gemini-2.5-pro"`
+
+## When you see errors
+
+**Type errors often mean your knowledge is outdated.**
+
+**Common signs of outdated knowledge:**
+
+- `Property X does not exist on type Y`
+- `Cannot find module`
+- `Type mismatch` errors
+- Constructor parameter errors
+
+**What to do:**
+
+1. Check [`references/common-errors.md`](references/common-errors.md)
+2. Verify current API in embedded docs
+3. Don't assume the error is a user mistake - it might be your outdated knowledge
+
+## Development workflow
+
+**Always verify before writing code:**
+
+1. **Check packages installed**
+
+   ```bash
+   ls node_modules/@mastra/
+   ```
+
+2. **Look up current API**
+   - If installed → Use embedded docs [`references/embedded-docs.md`](references/embedded-docs.md)
+   - If not → Use remote docs [`references/remote-docs.md`](references/remote-docs.md)
+
+3. **Write code based on current docs**
+
+4. **Test in Studio**
+   ```bash
+   npm run dev  # http://localhost:4111
+   ```
+
+## Resources
+
+- **Setup**: [`references/create-mastra.md`](references/create-mastra.md)
+- **Embedded docs lookup**: [`references/embedded-docs.md`](references/embedded-docs.md) - Start here if packages are installed
+- **Remote docs lookup**: [`references/remote-docs.md`](references/remote-docs.md)
+- **Common errors**: [`references/common-errors.md`](references/common-errors.md)
+- **Migrations**: [`references/migration-guide.md`](references/migration-guide.md)

--- a/.agents/skills/mastra/references/common-errors.md
+++ b/.agents/skills/mastra/references/common-errors.md
@@ -1,0 +1,537 @@
+# Common errors and troubleshooting
+
+Comprehensive guide to common Mastra errors and their solutions.
+
+## Quickstart
+
+In a lot of cases, debugging errors can be greatly simplified by first checking the behavior in Mastra Studio. This allows you to interactively test agents and workflows, inspect logs, and see real-time error messages.
+
+```bash
+npm run dev
+```
+
+Open `http://localhost:4111` in your browser to access Mastra Studio.
+
+## Build and configuration errors
+
+### "Cannot find module" or import errors
+
+**Symptoms**:
+
+```bash
+Error: Cannot find module '@mastra/core'
+SyntaxError: Cannot use import statement outside a module
+```
+
+**Causes**:
+
+- CommonJS configuration in `tsconfig.json`
+- Missing `"type": "module"` in `package.json`
+- Incorrect module resolution
+
+**Solutions**:
+
+1. Update `tsconfig.json`:
+
+   ```json
+   {
+     "compilerOptions": {
+       "target": "ES2022",
+       "module": "ES2022",
+       "moduleResolution": "bundler"
+     }
+   }
+   ```
+
+2. Add to `package.json`:
+
+   ```json
+   {
+     "type": "module"
+   }
+   ```
+
+3. Ensure imports use `.js` extensions for local files (if needed by your bundler)
+
+### "Property X does not exist on type Y"
+
+**Symptoms**:
+
+```bash
+Property 'tools' does not exist on type 'Agent'
+Property 'memory' does not exist on type 'AgentConfig'
+```
+
+**Causes**:
+
+- Outdated API usage (Mastra is actively developed)
+- Incorrect import or type
+- Version mismatch between docs and installed package
+
+**Solutions**:
+
+1. Check embedded docs (see `embedded-docs.md`) to check current API
+2. Check `node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json` for current exports
+3. Verify package versions: `npm list @mastra/core`
+4. Update dependencies: `npm update @mastra/core`
+
+## Agent errors
+
+### Agent not using assigned tools
+
+**Symptoms**:
+
+- Agent responds "I don't have access to that tool"
+- Tools never get called despite being relevant
+
+**Causes**:
+
+- Tools not registered in Mastra instance
+- Tools not passed to Agent constructor
+- Tool IDs don't match
+
+**Solutions**:
+
+**Correct pattern**:
+
+```typescript
+// 1. Create tool
+const weatherTool = createTool({
+  id: "get-weather",
+  // ... tool config
+});
+
+// 2. Register in Mastra instance
+const mastra = new Mastra({
+  tools: {
+    weatherTool, // or 'weatherTool': weatherTool
+  },
+});
+
+// 3. Assign to agent
+const agent = new Agent({
+  id: "weather-agent",
+  tools: { weatherTool }, // Reference the tool
+  // ... other config
+});
+```
+
+**Alternative pattern (direct assignment)**:
+
+```typescript
+const agent = new Agent({
+  id: "weather-agent",
+  tools: {
+    weatherTool: createTool({ id: "get-weather" /* ... */ }),
+  },
+});
+```
+
+### Agent memory not persisting
+
+**Symptoms**:
+
+- Agent doesn't remember previous messages
+- Conversation history is lost between calls
+
+**Causes**:
+
+- No storage backend configured
+- Missing or inconsistent `threadId`
+- Memory not assigned to agent
+
+**Solutions**:
+
+```typescript
+// 1. Configure storage
+const storage = new PostgresStore({
+  connectionString: process.env.DATABASE_URL,
+});
+
+// 2. Create memory with storage
+const memory = new Memory({
+  id: "chat-memory",
+  storage,
+  options: {
+    lastMessages: 10, // How many messages to retrieve
+  },
+});
+
+// 3. Assign memory to agent
+const agent = new Agent({
+  id: "chat-agent",
+  memory,
+});
+
+// 4. Use consistent threadId
+await agent.generate("Hello", {
+  threadId: "user-123-conversation", // Same threadId for entire conversation
+  resourceId: "user-123",
+});
+```
+
+## Workflow errors
+
+### "Cannot read property 'then' of undefined"
+
+**Symptoms**:
+
+```bash
+TypeError: Cannot read property 'then' of undefined
+Workflow execution fails immediately
+```
+
+**Causes**:
+
+- Forgot to call `.commit()` on workflow
+- Step returns undefined
+
+**Solutions**:
+
+**Correct pattern**:
+
+```typescript
+const workflow = createWorkflow({
+  id: "my-workflow",
+  inputSchema: z.object({ data: z.string() }),
+  outputSchema: z.object({ result: z.string() }),
+})
+  .then(step1)
+  .then(step2)
+  .commit(); // REQUIRED!
+
+// Then execute
+const run = await workflow.createRun();
+const result = await run.start({ inputData: { data: "test" } });
+```
+
+### Workflow state not updating
+
+**Symptoms**:
+
+- State changes don't persist across steps
+- `getStepResult()` returns undefined
+
+**Causes**:
+
+- Not using `setState` to update state
+- Accessing state before step completes
+
+**Solutions**:
+
+```typescript
+const step1 = createStep({
+  id: "step1",
+  execute: async ({ state, setState }) => {
+    // Update state
+    await setState({ ...state, counter: (state.counter || 0) + 1 });
+    return { result: "done" };
+  },
+});
+
+// Access state in subsequent steps
+const step2 = createStep({
+  id: "step2",
+  execute: async ({ state }) => {
+    console.log(state.counter); // Access updated state
+    return { result: "complete" };
+  },
+});
+```
+
+## Memory errors
+
+### "Storage is required for Memory"
+
+**Symptoms**:
+
+```bash
+Error: Storage is required for Memory
+Memory instantiation fails
+```
+
+**Causes**:
+
+- Memory created without storage backend
+
+**Solutions**:
+
+```typescript
+// Always provide storage when creating Memory
+const memory = new Memory({
+  id: "my-memory",
+  storage: postgresStore, // REQUIRED
+  options: {
+    lastMessages: 10,
+  },
+});
+```
+
+### Semantic recall not working
+
+**Symptoms**:
+
+- Memory doesn't retrieve semantically similar messages
+- Only recent messages are returned
+
+**Causes**:
+
+- No vector store configured
+- No embedder configured
+- `semanticRecall` not enabled
+
+**Solutions**:
+
+```typescript
+const memory = new Memory({
+  id: "semantic-memory",
+  storage: postgresStore,
+  vector: chromaVectorStore, // REQUIRED for semantic recall
+  embedder: openaiEmbedder, // REQUIRED for semantic recall
+  options: {
+    lastMessages: 10,
+    semanticRecall: true, // REQUIRED
+  },
+});
+```
+
+## Tool errors
+
+### "Tool validation failed"
+
+**Symptoms**:
+
+```bash
+Error: Input validation failed for tool 'my-tool'
+ZodError: Expected string, received number
+```
+
+**Causes**:
+
+- Input doesn't match inputSchema
+- Missing required fields
+- Type mismatch
+
+**Solutions**:
+
+```typescript
+const tool = createTool({
+  id: "my-tool",
+  inputSchema: z.object({
+    name: z.string(),
+    age: z.number().optional(), // Make optional fields explicit
+  }),
+  execute: async (input) => {
+    // input is validated and typed
+    return { result: `Hello ${input.name}` };
+  },
+});
+
+// Correct usage
+await tool.execute({ name: "Alice" }); // Works
+await tool.execute({ name: "Bob", age: 30 }); // Works
+await tool.execute({ age: 30 }); // ERROR: name is required
+```
+
+### Tool suspension not resuming
+
+**Symptoms**:
+
+- Tool suspends but never resumes
+- resumeData is undefined
+
+**Causes**:
+
+- Not calling workflow.resume() or agent.generate() with resumeData
+- Incorrect resumeSchema
+
+**Solutions**:
+
+```typescript
+const approvalTool = createTool({
+  id: "approval",
+  inputSchema: z.object({ request: z.string() }),
+  outputSchema: z.object({ approved: z.boolean() }),
+  suspendSchema: z.object({ requestId: z.string() }),
+  resumeSchema: z.object({ approved: z.boolean() }),
+  execute: async (input, context) => {
+    if (!context.resumeData) {
+      // First call - suspend
+      const requestId = generateId();
+      context.suspend({ requestId });
+      return; // Execution pauses here
+    }
+
+    // Resumed - use resumeData
+    return { approved: context.resumeData.approved };
+  },
+});
+
+// Resume the workflow/agent
+await run.resume({
+  resumeData: { approved: true },
+});
+```
+
+## Storage errors
+
+### "Connection refused" or "Database does not exist"
+
+**Symptoms**:
+
+```bash
+Error: connect ECONNREFUSED 127.0.0.1:5432
+Error: database "mastra" does not exist
+```
+
+**Causes**:
+
+- Database not running
+- Incorrect connection string
+- Database not created
+
+**Solutions**:
+
+1. Start database (Postgres example):
+
+```bash
+docker run -d \
+  --name mastra-postgres \
+  -e POSTGRES_PASSWORD=password \
+  -e POSTGRES_DB=mastra \
+  -p 5432:5432 \
+  postgres:16
+```
+
+2. Verify connection string:
+
+```env
+DATABASE_URL=postgresql://postgres:password@localhost:5432/mastra
+```
+
+3. Initialize storage:
+
+```typescript
+const storage = new PostgresStore({
+  connectionString: process.env.DATABASE_URL,
+});
+await storage.init(); // Creates tables if needed
+```
+
+## Environment variable errors
+
+### "API key not found"
+
+**Symptoms**:
+
+```bash
+Error: OPENAI_API_KEY environment variable is not set
+401 Unauthorized
+```
+
+**Causes**:
+
+- Missing .env file
+- Environment variables not loaded
+- Incorrect variable name
+
+**Solutions**:
+
+1. Create .env file:
+
+```env
+OPENAI_API_KEY=sk-...
+ANTHROPIC_API_KEY=sk-ant-...
+GOOGLE_GENERATIVE_AI_API_KEY=...
+```
+
+2. Load environment variables (for Node.js):
+
+```typescript
+import "dotenv/config"; // At top of entry file
+```
+
+3. Verify variable is loaded:
+
+```typescript
+if (!process.env.OPENAI_API_KEY) {
+  throw new Error("OPENAI_API_KEY is required");
+}
+```
+
+## Model errors
+
+### "Model not found" or "Invalid model"
+
+**Symptoms**:
+
+```bash
+Error: Model 'gpt-4' not found
+Error: Invalid model format
+```
+
+**Causes**:
+
+- Incorrect model format (should be `provider/model`)
+- Unsupported model
+- Missing provider API key
+
+**Solutions**:
+
+**Correct model format**:
+
+```typescript
+const agent = new Agent({
+  model: "openai/gpt-5.4", // ✅ Correct
+  // NOT: model: 'gpt-5.4'       // ❌ Missing provider
+});
+```
+
+**Common models**:
+
+- OpenAI: `openai/gpt-5.4`, `openai/gpt-5-mini`
+- Anthropic: `anthropic/claude-sonnet-4-5`, `anthropic/claude-haiku-4-5`, `anthropic/claude-opus-4-6`
+- Google: `google/gemini-2.5-pro`, `google/gemini-2.5-flash`
+
+**Use embedded docs to verify**:
+
+```bash
+# Check supported models
+ls node_modules/@mastra/core/dist/docs/
+# See embedded-docs.md for lookup instructions
+```
+
+## Debugging tips
+
+### Enable verbose logging
+
+```typescript
+const mastra = new Mastra({
+  logger: new PinoLogger({
+    name: "mastra",
+    level: "debug", // or 'trace' for even more detail
+  }),
+});
+```
+
+### Check package versions
+
+```bash
+npm list @mastra/core
+npm list @mastra/memory
+npm list @mastra/rag
+```
+
+### Validate TypeScript config
+
+```bash
+npx tsc --showConfig
+# Verify target: ES2022, module: ES2022
+```
+
+## Getting help
+
+1. **Check embedded docs**: Check embedded docs (see `embedded-docs.md`)
+2. **Search documentation**: [mastra.ai/docs](https://mastra.ai/docs)
+3. **Check version compatibility**: Ensure all @mastra packages are same version
+4. **File an issue**: [github.com/mastra-ai/mastra](https://github.com/mastra-ai/mastra)

--- a/.agents/skills/mastra/references/create-mastra.md
+++ b/.agents/skills/mastra/references/create-mastra.md
@@ -1,0 +1,222 @@
+# Create Mastra Reference
+
+Complete guide for creating new Mastra projects. Includes both quickstart CLI method and detailed manual installation.
+
+**Official documentation: [mastra.ai/docs](https://mastra.ai/docs)**
+
+## Get started
+
+Ask: **"How would you like to create your Mastra project?"**
+
+1. **Quick Setup**: Copy and run: `npm create mastra@latest`
+2. **Guided Setup**: I walk you through each step, you approve commands
+3. **Automatic Setup**: I create everything, just give me your API key
+
+> **For AI agents:** The CLI is interactive. Use **Automatic Setup** to create files using the steps in "Automatic Setup / Manual Installation" below.
+
+## Prerequisites
+
+- An API key from a supported model provider (OpenAI, Anthropic, Google, etc.)
+
+## Quick Setup (user runs CLI)
+
+Create a new Mastra project with one command:
+
+```bash
+npm create mastra@latest
+```
+
+**Other package managers:**
+
+```bash
+pnpm create mastra@latest
+yarn create mastra@latest
+bun create mastra@latest
+```
+
+## CLI flags
+
+**Skip the example agent:**
+
+```bash
+npm create mastra@latest --no-example
+```
+
+**Use a specific template:**
+
+```bash
+npm create mastra@latest --template <template-name>
+```
+
+## Automatic setup / manual installation
+
+**Use this for automatic setup** (AI creates all files) or when you prefer manual control.
+
+Follow these steps to create a complete Mastra project:
+
+### Step 1: Create project directory
+
+```bash
+mkdir my-first-agent && cd my-first-agent
+npm init -y
+```
+
+### Step 2: Install dependencies
+
+```bash
+npm install -D typescript @types/node mastra@latest
+npm install @mastra/core@latest zod@^4
+```
+
+### Step 3: Configure package scripts
+
+Add to `package.json`:
+
+```json
+{
+  "scripts": {
+    "dev": "mastra dev",
+    "build": "mastra build"
+  }
+}
+```
+
+### Step 4: Configure TypeScript
+
+Create `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}
+```
+
+**Important:** Mastra requires `"module": "ES2022"` and `"moduleResolution": "bundler"`. CommonJS will cause errors.
+
+### Step 5: Create environment file
+
+Create `.env` with your API key:
+
+```env
+GOOGLE_GENERATIVE_AI_API_KEY=<your-api-key>
+```
+
+Or use `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.
+
+### Step 6: Create weather tool
+
+Create `src/mastra/tools/weather-tool.ts`:
+
+```typescript
+import { createTool } from "@mastra/core/tools";
+import { z } from "zod";
+
+export const weatherTool = createTool({
+  id: "get-weather",
+  description: "Get current weather for a location",
+  inputSchema: z.object({
+    location: z.string().describe("City name"),
+  }),
+  outputSchema: z.object({
+    output: z.string(),
+  }),
+  execute: async () => {
+    return { output: "The weather is sunny" };
+  },
+});
+```
+
+### Step 7: Create weather agent
+
+Create `src/mastra/agents/weather-agent.ts`:
+
+```typescript
+import { Agent } from "@mastra/core/agent";
+import { weatherTool } from "../tools/weather-tool";
+
+export const weatherAgent = new Agent({
+  id: "weather-agent",
+  name: "Weather Agent",
+  instructions: `
+      You are a helpful weather assistant that provides accurate weather information.
+
+      Your primary function is to help users get weather details for specific locations. When responding:
+      - Always ask for a location if none is provided
+      - If the location name isn't in English, please translate it
+      - If giving a location with multiple parts (e.g. "New York, NY"), use the most relevant part (e.g. "New York")
+      - Include relevant details like humidity, wind conditions, and precipitation
+      - Keep responses concise but informative
+
+      Use the weatherTool to fetch current weather data.
+`,
+  model: "google/gemini-2.5-pro",
+  tools: { weatherTool },
+});
+```
+
+**Note:** Model format is `"provider/model-name"`. Examples:
+
+- `"google/gemini-2.5-pro"`
+- `"openai/gpt-5.4"`
+- `"anthropic/claude-sonnet-4-5"`
+
+### Step 8: Create mastra entry point
+
+Create `src/mastra/index.ts`:
+
+```typescript
+import { Mastra } from "@mastra/core";
+import { weatherAgent } from "./agents/weather-agent";
+
+export const mastra = new Mastra({
+  agents: { weatherAgent },
+});
+```
+
+### Step 9: Launch Mastra Studio
+
+Launch the development server:
+
+```bash
+npm run dev
+```
+
+Access Studio at `http://localhost:4111` to test your agent.
+
+## Next steps
+
+After creating your project with `create mastra`:
+
+- **Customize the example agent** in `src/mastra/agents/weather-agent.ts`
+- **Add new agents** - see [Agents documentation](https://mastra.ai/docs/agents/overview)
+- **Create workflows** - see [Workflows documentation](https://mastra.ai/docs/workflows/overview)
+- **Add more tools** to extend agent capabilities
+- **Integrate into your app** - see framework guides at [mastra.ai/docs](https://mastra.ai/docs)
+
+## Troubleshooting
+
+| Issue              | Solution                                                                             |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| API key not found  | Make sure your `.env` file has the correct key                                       |
+| Studio won't start | Check that port 4111 is available                                                    |
+| CommonJS errors    | Ensure `tsconfig.json` uses `"module": "ES2022"` and `"moduleResolution": "bundler"` |
+| Command not found  | Ensure you're using Node.js 20+                                                      |
+
+## Resources
+
+- [Docs](https://mastra.ai/docs)
+- [Installation](https://mastra.ai/docs/getting-started/installation)
+- [Agents](https://mastra.ai/docs/agents/overview)
+- [Workflows](https://mastra.ai/docs/workflows/overview)
+- [GitHub](https://github.com/mastra-ai/mastra)

--- a/.agents/skills/mastra/references/embedded-docs.md
+++ b/.agents/skills/mastra/references/embedded-docs.md
@@ -1,0 +1,103 @@
+# Embedded Docs Reference
+
+Look up API signatures from embedded docs in `node_modules/@mastra/*/dist/docs/` - these match the installed version.
+
+**Use this FIRST** when Mastra packages are installed locally. Embedded docs are always accurate for the installed version.
+
+## Why use embedded docs
+
+- **Version accuracy**: Embedded docs match the exact installed version
+- **No network required**: All docs are local in `node_modules/`
+- **Mastra evolves quickly**: APIs change rapidly, embedded docs stay in sync
+- **TypeScript definitions**: Includes JSDoc, type signatures, and examples
+- **Training data may be outdated**: Claude's knowledge cutoff may not reflect latest APIs
+
+## Documentation structure
+
+```
+node_modules/@mastra/core/dist/docs/
+├── SKILL.md # Package overview, exports
+├── assets/
+│   └── SOURCE_MAP.json # Export -> file mappings
+└── references/ # Individual topic docs
+```
+
+## Lookup process
+
+### 1. Check if packages are installed
+
+```bash
+ls node_modules/@mastra/
+```
+
+If you see packages like `core`, `memory`, `rag`, etc., proceed with embedded docs lookup.
+
+### 2. Look through topic docs
+
+Use `grep` to find relevant docs in `references/`:
+
+```bash
+grep -r "Agent" node_modules/@mastra/core/dist/docs/references
+```
+
+### Naming convention
+
+Documents are typically formatted as `<category>-<topic>.md` where category is one of: `"docs", "reference", "guides", "models"`.
+
+### Optional: Check source code for type definitions / additional details
+
+Look at the `SOURCE_MAP.json` to find the file path for the export:
+
+```bash
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"Agent"'
+```
+
+Returns: `{ "Agent": { "types": "dist/agent/agent.d.ts", ... } }`
+
+Read the type definition for exact constructor parameters, types, and JSDoc:
+
+```bash
+cat node_modules/@mastra/core/dist/agent/agent.d.ts
+```
+
+## Common packages
+
+| Package          | Path                                     | Contains                                  |
+| ---------------- | ---------------------------------------- | ----------------------------------------- |
+| `@mastra/core`   | `node_modules/@mastra/core/dist/docs/`   | Agents, Workflows, Tools, Mastra instance  |
+| `@mastra/memory` | `node_modules/@mastra/memory/dist/docs/` | Memory systems, conversation history      |
+| `@mastra/rag`    | `node_modules/@mastra/rag/dist/docs/`    | RAG features, vector stores               |
+| `@mastra/pg`     | `node_modules/@mastra/pg/dist/docs/`     | PostgreSQL storage                        |
+| `@mastra/libsql` | `node_modules/@mastra/libsql/dist/docs/` | LibSQL/SQLite storage                     |
+
+## Quick commands reference
+
+```bash
+# List installed @mastra packages
+ls node_modules/@mastra/
+
+# List available topic documentation
+ls node_modules/@mastra/core/dist/docs/references/
+
+# Find specific export in SOURCE_MAP
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"ExportName"'
+
+# Read type definition from path
+cat node_modules/@mastra/core/dist/[path-from-source-map]
+
+# View package overview
+cat node_modules/@mastra/core/dist/docs/SKILL.md
+```
+
+## When embedded docs are not available
+
+If packages aren't installed or `dist/docs/` doesn't exist:
+
+1. **Recommend installation**: Suggest installing packages to access embedded docs
+2. **Fall back to remote docs**: See `references/remote-docs.md`
+
+## Best Practices
+
+1. **Check topic docs** for conceptual understanding and patterns
+2. **Search source code** if docs don't answer the question
+3. **Verify imports** match what's exported in the type definitions

--- a/.agents/skills/mastra/references/migration-guide.md
+++ b/.agents/skills/mastra/references/migration-guide.md
@@ -1,0 +1,180 @@
+# Migration Guide
+
+Guide for upgrading Mastra versions using official documentation and current API verification.
+
+## Migration strategy
+
+For version upgrades, follow this process:
+
+### 1. Check official migration docs
+
+**Always start with the official migration documentation:** `https://mastra.ai/llms.txt`
+
+Look for the **Migrations** or **Guides** section, which will have:
+
+- Breaking changes for each version
+- Automated migration tools
+- Step-by-step upgrade instructions
+
+**Example sections to look for:**
+
+- `/guides/migrations/upgrade-to-v1/`
+- `/guides/migrations/upgrade-to-v2/`
+- Breaking changes lists
+
+### 2. Use embedded docs for current APIs
+
+After identifying breaking changes, verify the new APIs:
+
+**Check your installed version:**
+
+```bash
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"ApiName"'
+cat node_modules/@mastra/core/dist/[path-from-source-map]
+```
+
+See [`embedded-docs.md`](embedded-docs.md) for detailed lookup instructions.
+
+### 3. Use remote docs for latest info
+
+If packages aren't updated yet, check what APIs will look like: `https://mastra.ai/reference/[topic]`
+
+See [`remote-docs.md`](remote-docs.md) for detailed lookup instructions.
+
+## Quick migration workflow
+
+```bash
+# 1. Check current version
+npm list @mastra/core
+
+# 2. Fetch migration guide from official docs
+# Use WebFetch: https://mastra.ai/llms.txt
+# Find relevant migration section
+
+# 3. Update dependencies
+npm install @mastra/core@latest @mastra/memory@latest @mastra/rag@latest mastra@latest
+
+# 4. Run automated migration (if available)
+npx @mastra/codemod@latest v1  # or whatever version
+
+# 5. Check embedded docs for new APIs
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json
+
+# 6. Fix breaking changes using embedded docs lookup
+# See embedded-docs.md for how to look up each API
+
+# 7. Test
+npm run dev
+npm test
+```
+
+## Common migration patterns
+
+### Finding what changed
+
+**Check official migration docs:** `https://mastra.ai/guides/migrations/upgrade-to-v1/overview.md`
+
+This will list:
+
+- Breaking changes
+- Deprecated APIs
+- New features
+- Migration tools
+
+### Updating API usage
+
+**For each breaking change:**
+
+1. **Find the old API** in your code
+2. **Look up the new API** using embedded docs:
+   ```bash
+   cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"NewApi"'
+   cat node_modules/@mastra/core/dist/[path]
+   ```
+3. **Update your code** based on the type signatures
+4. **Test** the change
+
+### Example: Tool execute signature change
+
+**Official docs say:** "Tool execute signature changed"
+
+**Look up current signature:**
+
+```bash
+cat node_modules/@mastra/core/dist/docs/assets/SOURCE_MAP.json | grep '"createTool"'
+cat node_modules/@mastra/core/dist/tools/tool.d.ts
+```
+
+**Update based on type definition:**
+
+```typescript
+// Old (from docs)
+execute: async (input) => { ... }
+
+// New (from embedded docs)
+execute: async (inputData, context) => { ... }
+```
+
+## Pre-migration checklist
+
+- [ ] Backup code (git commit)
+- [ ] Check official migration docs: `https://mastra.ai/llms.txt`
+- [ ] Note current version: `npm list @mastra/core`
+- [ ] Read breaking changes list
+- [ ] Tests are passing
+
+## Post-migration checklist
+
+- [ ] All dependencies updated together
+- [ ] TypeScript compiles: `npx tsc --noEmit`
+- [ ] Tests pass: `npm test`
+- [ ] Studio works: `npm run dev`
+- [ ] No console warnings
+- [ ] APIs verified against embedded docs
+
+## Migration resources
+
+| Resource                               | Use For                                       |
+| -------------------------------------- | --------------------------------------------- |
+| `https://mastra.ai/llms.txt`           | Finding migration guides and breaking changes |
+| [`embedded-docs.md`](embedded-docs.md) | Looking up new API signatures after updating  |
+| [`remote-docs.md`](remote-docs.md)     | Checking latest docs before updating          |
+| [`common-errors.md`](common-errors.md) | Fixing migration errors                       |
+
+## Version-specific notes
+
+### General principles
+
+1. **Always update all @mastra packages together**
+
+   ```bash
+   npm install @mastra/core@latest @mastra/memory@latest @mastra/rag@latest mastra@latest
+   ```
+
+2. **Check for automated migration tools**
+
+   ```bash
+   npx @mastra/codemod@latest [version]
+   ```
+
+3. **Verify Node.js version requirements**
+   - Check official migration docs for minimum Node version
+
+4. **Run database migrations if using storage**
+   - Follow storage migration guide in official docs
+
+## Getting help
+
+1. **Check official migration docs**: `https://mastra.ai/llms.txt` → Migrations section
+2. **Look up new APIs**: See [`embedded-docs.md`](embedded-docs.md)
+3. **Check for errors**: See [`common-errors.md`](common-errors.md)
+4. **Ask in Discord**: https://discord.gg/BTYqqHKUrf
+5. **File issues**: https://github.com/mastra-ai/mastra/issues
+
+## Key principles
+
+1. **Official docs are source of truth** - Start with `https://mastra.ai/llms.txt`
+2. **Verify with embedded docs** - Check installed version APIs
+3. **Update incrementally** - Don't skip major versions
+4. **Test thoroughly** - Run tests after each change
+5. **Use automation** - Use codemods when available

--- a/.agents/skills/mastra/references/remote-docs.md
+++ b/.agents/skills/mastra/references/remote-docs.md
@@ -1,0 +1,193 @@
+# Remote Docs Reference
+
+How to look up current documentation from https://mastra.ai when local packages aren't available or you need conceptual guidance.
+
+**Use this when:**
+
+- Mastra packages aren't installed locally
+- You need conceptual explanations or guides
+- You want the latest documentation (may be ahead of installed version)
+
+## Documentation site structure
+
+Mastra docs are organized at **https://mastra.ai**:
+
+- **Docs**: Core documentation covering concepts, features, and implementation details
+- **Models**: Mastra provides a unified interface for working with LLMs across multiple providers
+- **Guides**: Step-by-step tutorials for building specific applications
+- **Reference**: API reference documentation
+
+## Finding relevant documentation
+
+### Method 1: Use llms.txt (Recommended)
+
+The main llms.txt file provides an agent-friendly overview of all documentation: https://mastra.ai/llms.txt
+
+This returns a structured markdown document with:
+
+- Documentation organization and hierarchy
+- All available topics and sections
+- Direct links to relevant documentation
+- Agent-optimized content structure
+
+**Use this first** to understand what documentation is available and where to find specific topics.
+
+### Method 2: Direct URL patterns
+
+Documentation follows predictable URL patterns:
+
+- Overview pages: `https://mastra.ai/docs/{topic}/overview`
+- API reference: `https://mastra.ai/reference/{topic}/`
+- Guides: `https://mastra.ai/guides/{topic}/`
+
+**Examples:**
+
+- `https://mastra.ai/docs/agents/overview`
+- `https://mastra.ai/docs/workflows/overview`
+- `https://mastra.ai/reference/workflows/workflow-methods/`
+
+## Agent-friendly documentation
+
+**Critical feature**: Send the `text-markdown` request header or add `.md` to any documentation URL to get clean, agent-friendly markdown.
+
+### Standard URL:
+
+```
+https://mastra.ai/reference/workflows/workflow-methods/then
+```
+
+### Agent-friendly URL (Markdown):
+
+```
+https://mastra.ai/reference/workflows/workflow-methods/then.md
+```
+
+The `.md` version:
+
+- Removes navigation, headers, footers
+- Returns pure markdown content
+- Optimized for LLM consumption
+- Includes all code examples and explanations
+
+## Lookup Workflow
+
+### 1. Check the main documentation index
+
+**Start here** to understand what's available:
+
+```
+https://mastra.ai/llms.txt
+```
+
+This provides:
+
+- Complete documentation structure
+- Available topics and sections
+- Links to relevant documentation pages
+
+### 2. Find relevant documentation
+
+**Option A: Use information from llms.txt**
+The main llms.txt will guide you to the right section.
+
+**Option B: Construct URL directly**
+
+```
+https://mastra.ai/docs/{topic}/overview
+https://mastra.ai/reference/{topic}/
+```
+
+### 3. Fetch agent-friendly version
+
+Add `.md` to the end of any documentation URL:
+
+```
+https://mastra.ai/reference/workflows/workflow-methods/then.md
+```
+
+### 4. Extract relevant information
+
+The markdown will include:
+
+- Function signatures
+- Parameter descriptions
+- Return types
+- Usage examples
+- Best practices
+
+## Common documentation paths
+
+### Agents
+
+- Overview: `https://mastra.ai/docs/agents/overview`
+- Creating agents: `https://mastra.ai/docs/agents/creating-agents`
+- Agent tools: `https://mastra.ai/docs/agents/tools`
+- Memory: `https://mastra.ai/docs/agents/memory`
+
+### Workflows
+
+- Overview: `https://mastra.ai/docs/workflows/overview`
+- Creating workflows: `https://mastra.ai/docs/workflows/creating-workflows`
+- Workflow methods: `https://mastra.ai/reference/workflows/workflow-methods/`
+
+### Tools
+
+- Overview: `https://mastra.ai/docs/tools/overview`
+- Creating tools: `https://mastra.ai/docs/tools/creating-tools`
+
+### Memory
+
+- Overview: `https://mastra.ai/docs/memory/overview`
+- Configuration: `https://mastra.ai/docs/memory/configuration`
+
+### RAG
+
+- Overview: `https://mastra.ai/docs/rag/overview`
+- Vector stores: `https://mastra.ai/docs/rag/vector-stores`
+
+## Example: Looking up workflow .then() method
+
+### 1. Check main documentation index
+
+```
+WebFetch({
+  url: "https://mastra.ai/llms.txt",
+  prompt: "Where can I find documentation about workflow methods like .then()?"
+})
+```
+
+This will point you to the workflows reference section.
+
+### 2. Fetch specific method documentation
+
+```
+https://mastra.ai/reference/workflows/workflow-methods/then.md
+```
+
+### 3. Use WebFetch tool
+
+```
+WebFetch({
+  url: "https://mastra.ai/reference/workflows/workflow-methods/then.md",
+  prompt: "What are the parameters for the .then() method and how do I use it?"
+})
+```
+
+## When to use remote vs embedded docs
+
+| Situation                  | Use                                                 |
+| -------------------------- | --------------------------------------------------- |
+| Packages installed locally | **Embedded docs** (guaranteed version match)        |
+| Packages not installed     | **Remote docs**                                     |
+| Need conceptual guides     | **Remote docs**                                     |
+| Need exact API signatures  | **Embedded docs** (if available)                    |
+| Exploring new features     | **Remote docs** (may be ahead of installed version) |
+| Need working examples      | **Both** (embedded for types, remote for guides)    |
+
+## Best practices
+
+1. **Always use .md** for fetching documentation
+2. **Check sitemap.xml** when unsure about URL structure
+3. **Prefer embedded docs** when packages are installed (version accuracy)
+4. **Use remote docs** for conceptual understanding and guides
+5. **Combine both** for comprehensive understanding

--- a/.agents/skills/mastra/scripts/provider-registry.mjs
+++ b/.agents/skills/mastra/scripts/provider-registry.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function findRegistryPath() {
+  const rel = join('node_modules', '@mastra', 'core', 'dist', 'provider-registry.json');
+  // Walk up from script location to find project root with node_modules
+  let dir = __dirname;
+  for (let i = 0; i < 10; i++) {
+    try {
+      const p = join(dir, rel);
+      readFileSync(p, "utf-8");
+      return p;
+    } catch {
+      dir = dirname(dir);
+    }
+  }
+  // Fall back to cwd
+  return join(process.cwd(), rel);
+}
+
+function loadRegistry() {
+  const path = findRegistryPath();
+  try {
+    return JSON.parse(readFileSync(path, "utf-8"));
+  } catch (e) {
+    console.error(`Error: Could not load provider registry at ${path}`);
+    console.error(e.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Extract version numbers from a model name for sorting.
+ * Returns an array of numeric segments, e.g. "gpt-5.4" → [5, 4].
+ * Handles dot-separated (3.5), hyphen-separated (3-7), and mixed formats.
+ * Models without detectable version numbers return null.
+ */
+function extractVersion(name) {
+  // Use named capture to grab version-like sequences along with their context.
+  // We capture digits separated by dots/hyphens, plus any trailing letter for filtering.
+  const regex = /(\d+(?:[.\-]\d+)*)([a-zA-Z])?/g;
+  const candidates = [];
+  let match;
+  while ((match = regex.exec(name)) !== null) {
+    const numStr = match[1];
+    const suffix = match[2] || "";
+    candidates.push({ numStr, suffix, index: match.index });
+  }
+  if (candidates.length === 0) return null;
+
+  // Process candidates: filter and clean up non-version parts
+  const processed = [];
+  for (const c of candidates) {
+    let parts = c.numStr.split(/[.\-]/).map(Number);
+    // If followed by a size suffix (b/B/k/K/m/M/t/T) — e.g. "8b", "70B", "1t" —
+    // strip the last numeric part (param count) but keep earlier parts as the version
+    if (/^[bBkKmMtT]$/.test(c.suffix)) {
+      parts = parts.slice(0, -1);
+      if (parts.length === 0) continue;
+    }
+    // Strip date-like segments (>= 2020 or YYYYMMDD-style 8-digit numbers)
+    parts = parts.filter((p) => p < 2020);
+    if (parts.length === 0) continue;
+    // Skip very large standalone numbers (parameter counts, IDs)
+    if (parts.length === 1 && parts[0] >= 100 && candidates.length > 1) continue;
+    // Skip trailing date-like patterns (MM-DD) in the latter half of the name
+    if (
+      parts.length === 2 &&
+      parts[0] >= 1 && parts[0] <= 12 &&
+      parts[1] >= 1 && parts[1] <= 31 &&
+      c.index > name.length / 2 &&
+      candidates.length > 1
+    ) continue;
+    processed.push(parts);
+  }
+
+  if (processed.length === 0) return null;
+
+  // Return the first valid version candidate (versions appear early in model names)
+  return processed[0];
+}
+
+function compareVersionsDesc(a, b) {
+  const va = extractVersion(a);
+  const vb = extractVersion(b);
+
+  // Models without versions go to the end
+  if (!va && !vb) return a.localeCompare(b);
+  if (!va) return 1;
+  if (!vb) return -1;
+
+  // Compare version tuples numerically, descending
+  const len = Math.max(va.length, vb.length);
+  for (let i = 0; i < len; i++) {
+    const ai = va[i] ?? 0;
+    const bi = vb[i] ?? 0;
+    if (bi !== ai) return bi - ai;
+  }
+  // Same version — secondary sort by full name descending
+  return b.localeCompare(a);
+}
+
+function printUsage() {
+  console.log(`Usage: provider-registry.mjs [options]
+
+Options:
+  --list               List all available model providers
+  --provider <name>    List all models for a provider (sorted newest first)
+  --help               Show this help message
+
+Examples:
+  node provider-registry.mjs --list
+  node provider-registry.mjs --provider openai
+  node provider-registry.mjs --provider anthropic`);
+}
+
+function listProviders(registry) {
+  const entries = Object.entries(registry.providers)
+    .map(([key, val]) => ({ key, name: val.name || key }))
+    .sort((a, b) => a.key.localeCompare(b.key));
+
+  const maxKey = Math.max(...entries.map((e) => e.key.length));
+  const maxName = Math.max(...entries.map((e) => e.name.length));
+
+  console.log(`${"PROVIDER".padEnd(maxKey)}  ${"NAME".padEnd(maxName)}  MODELS`);
+  console.log(`${"─".repeat(maxKey)}  ${"─".repeat(maxName)}  ${"─".repeat(6)}`);
+  for (const entry of entries) {
+    const modelCount = registry.providers[entry.key].models.length;
+    console.log(`${entry.key.padEnd(maxKey)}  ${entry.name.padEnd(maxName)}  ${modelCount}`);
+  }
+  console.log(`\n${entries.length} providers`);
+}
+
+function listModels(registry, providerName) {
+  const provider = registry.providers[providerName];
+  if (!provider) {
+    console.error(`Error: Provider "${providerName}" not found.`);
+    console.error(`Run with --list to see available providers.`);
+    process.exit(1);
+  }
+
+  const models = [...provider.models].sort(compareVersionsDesc);
+
+  console.log(`${provider.name || providerName} — ${models.length} models\n`);
+  for (const model of models) {
+    console.log(`  ${model}`);
+  }
+}
+
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.length === 0) {
+  printUsage();
+  process.exit(0);
+}
+
+if (args.includes("--list")) {
+  listProviders(loadRegistry());
+  process.exit(0);
+}
+
+const providerIdx = args.indexOf("--provider");
+if (providerIdx !== -1) {
+  const name = args[providerIdx + 1];
+  if (!name) {
+    console.error("Error: --provider requires a provider name.");
+    process.exit(1);
+  }
+  listModels(loadRegistry(), name);
+  process.exit(0);
+}
+
+console.error("Error: Unknown arguments:", args.join(" "));
+printUsage();
+process.exit(1);

--- a/.claude/skills/mastra
+++ b/.claude/skills/mastra
@@ -1,0 +1,1 @@
+../../.agents/skills/mastra

--- a/.pi/skills/mastra
+++ b/.pi/skills/mastra
@@ -1,0 +1,1 @@
+../../.agents/skills/mastra

--- a/.skills/mastra
+++ b/.skills/mastra
@@ -1,0 +1,1 @@
+../.agents/skills/mastra

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "skills": {
+    "mastra": {
+      "source": "mastra-ai/skills",
+      "sourceType": "github",
+      "computedHash": "b42f583342dfee7deb541f4d094f03e8748898257f1f884fa71de1fdba9f38a2"
+    },
+    "moon": {
+      "source": "hyperb1iss/moonrepo-skill",
+      "sourceType": "github",
+      "computedHash": "b09592c8023529035c8c116d0af3dae32af87e818f69879ee916b8bdabc28f36"
+    },
+    "proto": {
+      "source": "hyperb1iss/moonrepo-skill",
+      "sourceType": "github",
+      "computedHash": "71ac82a46f0fee0ede59310c37ea4cb5c00bdee0ac8cef56361c9fcc5e898d50"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds the Mastra skill (`skills-lock.json`, `.agents/skills/mastra/`) with comprehensive documentation on the Mastra framework
- Includes references for setup, embedded/remote docs lookup, common errors, and migration guide
- Symlinked for Claude (`.claude/`), Pi (`.pi/`), and generic agent (`.skills/`) ecosystems

## Test plan

- [ ] Verify skill loads correctly via agent skill system
- [ ] Check that Mastra references are accessible from `.agents/skills/mastra/references/`
- [ ] Confirm symlinks in `.claude/`, `.pi/`, `.skills/` resolve correctly

👾 Generated with [Letta Code](https://letta.com)