### PR TITLE
chore: add pnpm minimum release age

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,5 @@
+minimumReleaseAge: 10080 # 7 days, in minutes
+
 onlyBuiltDependencies:
   - esbuild
   - sharp


### PR DESCRIPTION
## Summary

- Add `minimumReleaseAge: 10080` to `pnpm-workspace.yaml`
- Enforce a 7-day package release-age gate for pnpm installs

## Why

This helps mitigate supply-chain attacks where a malicious or compromised package version is published and consumed immediately after release.

Closes #12

## Verification

- [x] `pnpm config get minimumReleaseAge` returns `10080`
- [x] `pnpm config list --json` includes `"minimum-release-age": 10080`
- [x] `pnpm install --frozen-lockfile --ignore-scripts`